### PR TITLE
Fix file path joining in DataLoaders.py

### DIFF
--- a/lvae3d/util/DataLoaders.py
+++ b/lvae3d/util/DataLoaders.py
@@ -12,7 +12,7 @@ class Dataset3D(Dataset):
 
     def __init__(self, root_dir):
         self.root_dir = root_dir
-        self.filenames = sorted(glob.glob(f'{self.root_dir}*.pt'))
+        self.filenames = sorted(glob.glob(os.path.join(self.root_dir, "*.pt")))
 
     def __len__(self):
         return len(self.filenames)


### PR DESCRIPTION
In `DataLoaders.py` `self.filenames = sorted(glob.glob(f'{self.root_dir}*.pt'))` caused a problem with directories ending without a `'/'`character. It required that `root_dir` must end with a slash `(/)` and the `.pt` files must be directly inside that folder. 


The missing `/` before the `*.pt` means it never enters the directory, so it finds `0` files. That’s why the dataset length is 0 and the DataLoader failed earlier.

Easy fix -

```python
self.filenames = sorted(glob.glob(f'{self.root_dir}*.pt'))
```

becomes


```python
self.filenames = sorted(glob.glob(os.path.join(self.root_dir, "*.pt")))
```

This way, it doesn't matter if one passes the directory with or without `/`.